### PR TITLE
Deleted incognite flag and Changed config path to standard

### DIFF
--- a/cncjs_install.sh
+++ b/cncjs_install.sh
@@ -42,7 +42,7 @@ SYSTEM_CHECK=true  # Preform system check to insure this script is known to be c
 
 CNCJS_EXT_DIR="${HOME}/.cncjs"
 CNCJS_PORT=80
-cncjs_flags="--port ${CNCJS_PORT} --config \\\"${CNCJS_EXT_DIR}/cncrc.cfg\\\" --watch-directory \\\"${CNCJS_EXT_DIR}/watch\\\""  # --host ${HOST_IP}
+cncjs_flags="--port ${CNCJS_PORT} --watch-directory \\\"${CNCJS_EXT_DIR}/watch\\\""  # --host ${HOST_IP}
 COMPATIBLE_OS_ID='^(rasp|de)bian$'
 COMPATIBLE_OS_ID_VERSION=11  # greater than or equal
 
@@ -770,7 +770,7 @@ Environment="NODE_ENV=production"
 # CNCjs Parameters
 $(cncjs --help | grep .  | sed '1d;$d' | sed 's/^/#/')
 # cncjs --help
-ExecStart=$(which cncjs) --port 80 --config \"${CNCJS_EXT_DIR}/.cncrc\" --watch-directory \"${HOME}/Documents\"
+ExecStart=$(which cncjs) --port 80 --watch-directory \"${HOME}/Documents\"
 
 # = Alternative Method = (EnvironmentFile)
 #EnvironmentFile=-/etc/cncjs.d/default.conf

--- a/cncjs_install.sh
+++ b/cncjs_install.sh
@@ -1029,7 +1029,7 @@ sed -i 's/"exited_cleanly":false/"exited_cleanly":true/; s/"exit_type":"[^"]\+"/
 # --kiosk makes the browser occupy the entire screen.
 # If you want to kill the full-screen browser, use ALT-F4
 # If you omit --kiosk, the browser will start in a normal window
-chromium-browser  --incognito --kiosk --noerrdialogs --disable-cache --disk-cache-dir=/dev/null --disk-cache-size=1 --disable-suggestions-service --disable-translate --disable-save-password-bubble --disable-session-crashed-bubble --disable-infobars --touch-events=enabled --no-touch-pinch --disable-gesture-typing "${KIOSK_URL}"
+chromium-browser --kiosk --noerrdialogs --disable-cache --disk-cache-dir=/dev/null --disk-cache-size=1 --disable-suggestions-service --disable-translate --disable-save-password-bubble --disable-session-crashed-bubble --disable-infobars --touch-events=enabled --no-touch-pinch --disable-gesture-typing "${KIOSK_URL}"
 EOF
 	# --------------------------------------------
 


### PR DESCRIPTION
1. Deletet the --incognito option from the chromium kiosk. Now you can change language, delete widgets etc. and it will be restored after reboot.

2. Deleted the --config flag frim the CNCjs installation, had some problems with installing the "Auto-leveling extension for CNCjs" because it assumes standard config path...